### PR TITLE
feat: FreshnessBadge + card updates

### DIFF
--- a/src/components/badges/FreshnessBadge.astro
+++ b/src/components/badges/FreshnessBadge.astro
@@ -1,0 +1,29 @@
+---
+interface Props {
+  lastUpdated: string | null; // ISO date string 'YYYY-MM-DD'
+  showLabel?: boolean;
+}
+
+const { lastUpdated, showLabel = true } = Astro.props;
+
+function getFreshness(dateStr: string | null): { color: string; label: string; dot: string } {
+  if (!dateStr) return { color: 'var(--stale)', label: 'Unknown', dot: 'bg-stale' };
+  
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = diffMs / (1000 * 60 * 60);
+  const diffDays = diffHours / 24;
+
+  if (diffHours < 24) return { color: 'var(--fresh)', label: 'Updated today', dot: 'bg-fresh' };
+  if (diffDays < 7)  return { color: 'var(--recent)', label: 'Updated this week', dot: 'bg-recent' };
+  return { color: 'var(--stale)', label: `Updated ${Math.floor(diffDays)}d ago`, dot: 'bg-stale' };
+}
+
+const freshness = getFreshness(lastUpdated);
+---
+
+<span class="inline-flex items-center gap-1.5 text-xs font-mono" style={`color: ${freshness.color}`}>
+  <span class={`w-1.5 h-1.5 rounded-full ${freshness.dot}`}></span>
+  {showLabel && <span>{freshness.label}</span>}
+</span>

--- a/src/components/cards/EntityCard.astro
+++ b/src/components/cards/EntityCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { WikiEntity } from '../../data/types';
 import TypeBadge from '../badges/TypeBadge.astro';
+import FreshnessBadge from '../badges/FreshnessBadge.astro';
 
 interface Props {
   entity: WikiEntity;
@@ -20,8 +21,6 @@ const { entity } = Astro.props;
     ) : (
       <p class="text-sm text-gray-600 italic">Profile pending enrichment</p>
     )}
-    {entity.lastUpdated && (
-      <p class="text-xs text-gray-600 font-mono mt-2">Updated {entity.lastUpdated}</p>
-    )}
+    <FreshnessBadge lastUpdated={entity.lastUpdated} />
   </article>
 </a>

--- a/src/components/cards/EventCard.astro
+++ b/src/components/cards/EventCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { WikiEvent } from '../../data/types';
 import StatusBadge from '../badges/StatusBadge.astro';
+import FreshnessBadge from '../badges/FreshnessBadge.astro';
 
 interface Props {
   event: WikiEvent;
@@ -32,9 +33,7 @@ const latestTimeline = event.timeline.length > 0
       {latestTimeline && (
         <p class="text-sm text-gray-400 line-clamp-2 flex-1">{latestTimeline.replace(/^\d{4}-\d{2}-\d{2}\s*/, '')}</p>
       )}
-      {event.lastUpdated && (
-        <span class="text-xs text-gray-600 font-mono ml-2 shrink-0">{event.lastUpdated}</span>
-      )}
+      <FreshnessBadge lastUpdated={event.lastUpdated} />
     </div>
   </article>
 </a>

--- a/src/components/cards/MarketCard.astro
+++ b/src/components/cards/MarketCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { WikiMarket } from '../../data/types';
 import { formatVolume } from '../../data/svg-chart';
+import FreshnessBadge from '../badges/FreshnessBadge.astro';
 
 interface Props {
   market: WikiMarket;
@@ -27,5 +28,6 @@ const noPercent = market.currentProbability.no;
       <span>Vol: {formatVolume(market.volumeRaw)}</span>
       <span class="text-gray-600">{market.history.length} data points</span>
     </div>
+    <FreshnessBadge lastUpdated={market.endDate} />
   </article>
 </a>

--- a/src/components/cards/NarrativeCard.astro
+++ b/src/components/cards/NarrativeCard.astro
@@ -1,5 +1,6 @@
 ---
 import type { WikiNarrative } from '../../data/types';
+import FreshnessBadge from '../badges/FreshnessBadge.astro';
 
 interface Props {
   narrative: WikiNarrative;
@@ -31,5 +32,6 @@ const previewText = narrative.summary
         })}
       </div>
     )}
+    <FreshnessBadge lastUpdated={narrative.firstObserved} />
   </article>
 </a>


### PR DESCRIPTION
## Summary
- Created `FreshnessBadge.astro` component with color-coded freshness: green (<24h), amber (<7d), grey (>7d)
- Added FreshnessBadge to EventCard, EntityCard, MarketCard, NarrativeCard

## Changes
- **Created:** `src/components/badges/FreshnessBadge.astro`
- **Modified:** `src/components/cards/EventCard.astro` — replaced lastUpdated span
- **Modified:** `src/components/cards/EntityCard.astro` — replaced lastUpdated paragraph
- **Modified:** `src/components/cards/MarketCard.astro` — added after volume row
- **Modified:** `src/components/cards/NarrativeCard.astro` — added at bottom of card

## Verification
`astro build` completed successfully (910 pages built)