### PR TITLE
Issue #8: SSH-based deploy workflow + .env.example update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
-# Wiki data source - the SigInt pipeline writes to /home/paperclip/signal-intelligence/
+# SigInt data source (VPS only — NOT used in CI builds)
 WIKI_DATA_ROOT=/home/paperclip/signal-intelligence
-BUILT_AT=${{ github.event.head_commit.timestamp }}
+
+# Build timestamp (injected at build time)
+BUILT_AT=

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,37 +1,23 @@
-name: Build and Deploy Wiki
+name: Deploy Wiki
 
 on:
   push:
-    branches: [slice-7]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Deploy to VPS via SSH
+        uses: appleboy/ssh-action@v1
         with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build site
-        env:
-          WIKI_DATA_ROOT: /home/paperclip/signal-intelligence
-          BUILT_AT: ${{ github.event.head_commit.timestamp }}
-        run: npm run build
-
-      - name: Deploy via rsync
-        uses: burnett01/rsync-deployments@7.0.0
-        with:
-          switches: -avz --delete
-          remote_path: /home/hermes/sigint-wiki/dist/
-          remote_host: ${{ secrets.VPS_HOST }}
-          remote_user: hermes
-          remote_key: ${{ secrets.VPS_SSH_KEY }}
+          host: ${{ secrets.VPS_HOST }}
+          username: hermes
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd /home/hermes/sigint-wiki
+            git pull origin main
+            npm ci
+            npm run build
+            echo "Deployed at $(date -u)"


### PR DESCRIPTION
Implements Issues #28 and #31 from Issue #8 epic.

Changes:
- Issue #28 (T2): Replaced CI-based rsync deploy with SSH-based VPS deploy (appleboy/ssh-action). Build runs on VPS via SSH.
- Issue #31 (T5): Updated .env.example to remove GitHub Actions template variable.

Verification:
- scripts/build.sh paths verified correct (uses default /home/paperclip/signal-intelligence)
- astro.config.mjs verified clean (no hardcoded paths)

BLOCKER: VPS_HOST and VPS_SSH_KEY secrets NOT yet configured in GitHub. Must be added before workflow can deploy.

Issue #27 (T1) - slice-7 to main merge - already completed separately.