### PR TITLE
fix: misleading timestamps on entities and events (#40)

### DIFF
--- a/DESIGN-BRIEF.md
+++ b/DESIGN-BRIEF.md
@@ -144,7 +144,7 @@ Key design elements:
 - **Hero**: Tight, compressed headline at 48px Inter 510 with negative tracking. Not big and shouty — precise and confident.
 - **Live stats**: Monospace counter with teal accent dots. Feels like a terminal readout.
 - **Sample cards**: 3 cards showing the depth of each content type. Freshness indicators visible.
-- **"Today's Brief →"**: Links to intel.zyoulabs.ai. Subtle but present.
+- **"Browse Events →"**: Links to /events. Subtle but present.
 - **How it works**: Brief methodology section. Shows the AI pipeline as a feature.
 
 ### 2. Entity Detail Page
@@ -269,27 +269,7 @@ Interactions:
   - Graph animates in on page load
 ```
 
----
 
-## intel.zyoulabs.ai Direction
-
-Separate visual identity — same dark base but different accent:
-
-```
-Accent: Warm amber (#f59e0b) instead of teal
-Fonts: Same Inter system
-Vibe: "Your daily intelligence briefing" — more report-like, less wiki-like
-Structure:
-  - Today's brief (hero)
-  - Market signals dashboard
-  - Narrative divergence alerts
-  - Scenario spotlight
-  - Links back to wiki for deep dives
-```
-
-This is Phase 2+ — scaffold the domain now, design later.
-
----
 
 ## Implementation Notes
 

--- a/src/components/badges/FreshnessBadge.astro
+++ b/src/components/badges/FreshnessBadge.astro
@@ -2,14 +2,20 @@
 interface Props {
   lastUpdated: string | null; // ISO date string 'YYYY-MM-DD'
   showLabel?: boolean;
+  isStub?: boolean; // If true, show "Profile pending" instead of misleading "Updated today"
 }
 
-const { lastUpdated, showLabel = true } = Astro.props;
+const { lastUpdated, showLabel = true, isStub = false } = Astro.props;
+
+// Don't render anything if lastUpdated is null
+if (!lastUpdated) return;
+
+// For stub entities with no real content, don't show a misleading freshness label
+if (isStub) return;
 
 function getFreshness(dateStr: string | null): { color: string; label: string; dot: string } {
-  if (!dateStr) return { color: 'var(--stale)', label: 'Unknown', dot: 'bg-stale' };
-  
   const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return { color: 'var(--stale)', label: 'Date unknown', dot: 'bg-stale' };
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffHours = diffMs / (1000 * 60 * 60);

--- a/src/components/badges/StatusBadge.astro
+++ b/src/components/badges/StatusBadge.astro
@@ -15,6 +15,10 @@ const statusConfig: Record<string, { bg: string; text: string; dot: string }> = 
 };
 
 const normalized = statusKeyword.toLowerCase().trim();
+
+// Don't render anything for empty or "unknown" statuses — they add no information
+if (!normalized || normalized === 'unknown') return;
+
 const config = statusConfig[normalized] || { bg: 'bg-gray-500/15', text: 'text-gray-400', dot: 'bg-gray-400' };
 
 const displayLabel = normalized === 'active (strain)' ? 'Active · Strain' : statusKeyword.charAt(0).toUpperCase() + statusKeyword.slice(1);

--- a/src/components/cards/EntityCard.astro
+++ b/src/components/cards/EntityCard.astro
@@ -8,6 +8,9 @@ interface Props {
 }
 
 const { entity } = Astro.props;
+
+// An entity is a "stub" if it has no meaningful content beyond title and type
+const isStub = !entity.affiliations && !entity.objectives && !entity.claimsAndTrackRecord;
 ---
 
 <a href={`/entities/${entity.slug}`} class="block group">
@@ -16,13 +19,15 @@ const { entity } = Astro.props;
       <h3 class="text-gray-100 font-semibold text-base leading-snug group-hover:text-brand-400 transition-colors">{entity.title}</h3>
       <TypeBadge type={entity.type} />
     </div>
-    {entity.affiliations ? (
-      <p class="text-sm text-gray-400">{entity.affiliations}</p>
-    ) : (
+    {isStub ? (
       <p class="text-sm text-gray-600 italic">Profile pending enrichment</p>
-    )}
-    {entity.lastUpdated && (
-      <div class="mt-2"><FreshnessBadge lastUpdated={entity.lastUpdated} /></div>
+    ) : (
+      <>
+        {entity.affiliations && <p class="text-sm text-gray-400">{entity.affiliations}</p>}
+        {entity.lastUpdated && (
+          <div class="mt-2"><FreshnessBadge lastUpdated={entity.lastUpdated} /></div>
+        )}
+      </>
     )}
   </article>
 </a>

--- a/src/components/cards/EventCard.astro
+++ b/src/components/cards/EventCard.astro
@@ -33,7 +33,7 @@ const latestTimeline = event.timeline.length > 0
       {latestTimeline && (
         <p class="text-sm text-gray-400 line-clamp-2 flex-1">{latestTimeline.replace(/^\d{4}-\d{2}-\d{2}\s*/, '')}</p>
       )}
-      {event.pageUpdated && <FreshnessBadge lastUpdated={event.pageUpdated} label="Page updated" />}
+      {event.pageUpdated && <FreshnessBadge lastUpdated={event.pageUpdated} />}
     </div>
   </article>
 </a>

--- a/src/components/cards/EventCard.astro
+++ b/src/components/cards/EventCard.astro
@@ -33,7 +33,7 @@ const latestTimeline = event.timeline.length > 0
       {latestTimeline && (
         <p class="text-sm text-gray-400 line-clamp-2 flex-1">{latestTimeline.replace(/^\d{4}-\d{2}-\d{2}\s*/, '')}</p>
       )}
-      <FreshnessBadge lastUpdated={event.lastUpdated} />
+      {event.pageUpdated && <FreshnessBadge lastUpdated={event.pageUpdated} label="Page updated" />}
     </div>
   </article>
 </a>

--- a/src/components/sections/TimelineSection.astro
+++ b/src/components/sections/TimelineSection.astro
@@ -9,6 +9,10 @@ function parseTimelineEntry(entry: string): { date: string; sortKey: string; tex
   const time = dtMatch && dtMatch[2] ? dtMatch[2] : '00:00';
   const sortKey = date ? date + 'T' + time : '';
   let rest = dtMatch ? entry.slice(dtMatch[0].length) : entry;
+
+  // Clean up malformed date artifacts (e.g. "2026-04-17) Unknown" -> strip leading ")" and whitespace)
+  rest = rest.replace(/^\)\s*/, '');
+
   const dashIndex = rest.lastIndexOf('—');
   let text = rest;
   let attribution = '';

--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -72,10 +72,12 @@ export function loadAllEvents(): WikiEvent[] {
   const files = readDir(dir);
 
   return files.map((file) => {
-    const raw = readFile(path.join(dir, file));
+    const filePath = path.join(dir, file);
+    const raw = readFile(filePath);
     const slug = slugFromFilename(file);
     const title = extractTitle(raw);
     const sections = parseSectionMarkdown(raw);
+    const timeline = parseBulletList(sections, 'timeline');
 
     return {
       slug,
@@ -83,11 +85,12 @@ export function loadAllEvents(): WikiEvent[] {
       status: parseSingleLine(sections, 'status'),
       theatre: parseSingleLine(sections, 'theatre'),
       themes: parseCommaList(sections, 'themes'),
-      timeline: parseBulletList(sections, 'timeline'),
+      timeline,
       narrativeDivergence: parseTextBlock(sections, 'narrative divergence'),
       relatedEntities: cleanBulletList(parseBulletList(sections, 'related entities')),
       relatedMarkets: cleanBulletList(parseBulletList(sections, 'related markets')),
-      lastUpdated: extractLatestDateFromTimeline(parseBulletList(sections, 'timeline')),
+      lastUpdated: extractLatestDateFromTimeline(timeline),
+      pageUpdated: fs.statSync(filePath).mtime.toISOString().split('T')[0],
     };
   }).sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''));
 }
@@ -97,7 +100,8 @@ export function loadAllEntities(): WikiEntity[] {
   const files = readDir(dir);
 
   return files.map((file) => {
-    const raw = readFile(path.join(dir, file));
+    const filePath = path.join(dir, file);
+    const raw = readFile(filePath);
     const slug = slugFromFilename(file);
     const title = extractTitle(raw);
     const sections = parseSectionMarkdown(raw);
@@ -112,6 +116,7 @@ export function loadAllEntities(): WikiEntity[] {
       divergences: parseTextBlock(sections, 'divergences'),
       connections: parseTextBlock(sections, 'connections'),
       lastUpdated: extractLatestDateFromRaw(raw),
+      pageUpdated: fs.statSync(filePath).mtime.toISOString().split('T')[0],
     };
   }).sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''));
 }
@@ -123,7 +128,8 @@ export function loadAllMarkets(): WikiMarket[] {
   const moversEndDate = loadEndDateLookup();
 
   return files.map((file) => {
-    const raw = readFile(path.join(dir, file));
+    const filePath = path.join(dir, file);
+    const raw = readFile(filePath);
     const slug = slugFromFilename(file);
     const title = extractTitle(raw);
     const sections = parseSectionMarkdown(raw);
@@ -158,6 +164,7 @@ export function loadAllMarkets(): WikiMarket[] {
       endDate: endDate ? endDate.toISOString() : null,
       expired: endDate !== null && endDate < now,
       lastUpdated: extractLatestDateFromRaw(raw),
+      pageUpdated: fs.statSync(filePath).mtime.toISOString().split('T')[0],
     };
   });
 }
@@ -186,7 +193,8 @@ export function loadAllNarratives(): WikiNarrative[] {
   const files = readDir(dir);
 
   return files.map((file) => {
-    const raw = readFile(path.join(dir, file));
+    const filePath = path.join(dir, file);
+    const raw = readFile(filePath);
     const slug = slugFromFilename(file);
     const title = extractTitle(raw);
     const sections = parseSectionMarkdown(raw);
@@ -201,6 +209,7 @@ export function loadAllNarratives(): WikiNarrative[] {
       counterNarratives: parseBulletList(sections, 'counter-narratives'),
       relatedEvents: cleanBulletList(parseBulletList(sections, 'related events')),
       lastUpdated: extractLatestDateFromRaw(raw),
+      pageUpdated: fs.statSync(filePath).mtime.toISOString().split('T')[0],
     };
   });
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -8,7 +8,8 @@ export interface WikiEvent {
   narrativeDivergence: string | null;
   relatedEntities: string[];
   relatedMarkets: string[];
-  lastUpdated: string | null;
+  lastUpdated: string | null; // Latest timeline entry date (event occurrence)
+  pageUpdated: string | null; // When the wiki page was last modified
 }
 
 export interface WikiEntity {
@@ -20,7 +21,8 @@ export interface WikiEntity {
   claimsAndTrackRecord: string | null;
   divergences: string | null;
   connections: string | null;
-  lastUpdated: string | null;
+  lastUpdated: string | null; // Latest date found in entity file (if any)
+  pageUpdated: string | null; // When the wiki page was last modified
 }
 
 export interface WikiMarket {
@@ -36,6 +38,7 @@ export interface WikiMarket {
   endDate: string | null;
   expired: boolean;
   lastUpdated: string | null;
+  pageUpdated: string | null; // When the wiki page was last modified
 }
 
 export interface WikiNarrative {
@@ -48,6 +51,7 @@ export interface WikiNarrative {
   counterNarratives: string[];
   relatedEvents: string[];
   lastUpdated: string | null;
+  pageUpdated: string | null; // When the wiki page was last modified
 }
 
 export interface IntelligenceBrief {

--- a/src/pages/briefs/[...date].astro
+++ b/src/pages/briefs/[...date].astro
@@ -68,7 +68,12 @@ const scenarioSubs = dailyBrief ? parseSubsections(dailyBrief.scenarioSpotlight)
 const hasScenarioSubsections = scenarioSubs.length > 1;
 ---
 
-<BaseLayout title={pageTitle} description={`Intelligence analysis for ${resolvedDate}`} breadcrumbs={[{ label: 'Briefs', href: '/briefs/latest' }, { label: resolvedDate }]}>
+<BaseLayout title={pageTitle} description={`Intelligence analysis for ${resolvedDate}`} breadcrumbs={[{ label: 'Briefs', href: '/briefs/latest' }, { label: resolvedDate }]}
+  footerType="brief"
+  footerUpdatedBy="Compiler"
+  footerUpdatedAt={resolvedDate !== 'latest' ? resolvedDate : null}
+  footerSourceCount={collectorBriefs.length}
+>
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 mb-2">Daily Intelligence Brief</h1>
     <div class="flex items-center gap-3 text-gray-400">

--- a/src/pages/briefs/[...date].astro
+++ b/src/pages/briefs/[...date].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import { loadDailyBriefByDate, loadAllDailyBriefs, loadBriefsByDate } from '../../data/loader';
 import { marked } from 'marked';
 
@@ -69,13 +70,14 @@ const hasScenarioSubsections = scenarioSubs.length > 1;
 ---
 
 <BaseLayout title={pageTitle} description={`Intelligence analysis for ${resolvedDate}`} breadcrumbs={[{ label: 'Briefs', href: '/briefs/latest' }, { label: resolvedDate }]}
-  footerType="brief"
-  footerUpdatedBy="Compiler"
-  footerUpdatedAt={resolvedDate !== 'latest' ? resolvedDate : null}
+  footerType="page"
+  footerUpdatedBy="Analyst"
+  footerUpdatedAt={dailyBrief?.date || resolvedDate}
   footerSourceCount={collectorBriefs.length}
 >
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 mb-2">Daily Intelligence Brief</h1>
+    <AIAuthoredBadge />
     <div class="flex items-center gap-3 text-gray-400">
       <span class="font-mono text-brand-400">{resolvedDate}</span>
       {dailyBrief && (

--- a/src/pages/entities/[slug].astro
+++ b/src/pages/entities/[slug].astro
@@ -54,7 +54,7 @@ const isStub = !entity.affiliations && !entity.objectives && !entity.claimsAndTr
     </div>
     <div class="flex items-center gap-4 text-xs text-[var(--text-faint)]">
       {entity.pageUpdated && (
-        <FreshnessBadge lastUpdated={entity.pageUpdated} label="Page updated" isStub={isStub} />
+        <FreshnessBadge lastUpdated={entity.pageUpdated} isStub={isStub} />
       )}
       {!isStub && <span>·</span>}
       <span class="font-mono">{mentioningEvents.length} events referencing</span>

--- a/src/pages/entities/[slug].astro
+++ b/src/pages/entities/[slug].astro
@@ -20,13 +20,13 @@ export function getStaticPaths() {
 const { entity } = Astro.props;
 const xref = buildCrossReferences();
 const mentioningEvents = xref.eventsMentioningEntity(entity.slug);
-const diffHours = entity.lastUpdated
-  ? Math.floor((Date.now() - new Date(entity.lastUpdated).getTime()) / (1000 * 60 * 60))
-  : null;
 // Derive related events (slugs) and markets (slugs) for D3 graph from cross-references
 const relatedEvents = mentioningEvents.map(e => e.slug);
 // Collect unique market slugs from all events that mention this entity
 const relatedMarkets = [...new Set(mentioningEvents.flatMap(e => e.relatedMarkets))];
+
+// An entity is a "stub" if it has no meaningful content beyond title and type
+const isStub = !entity.affiliations && !entity.objectives && !entity.claimsAndTrackRecord;
 ---
 
 <BaseLayout
@@ -35,7 +35,7 @@ const relatedMarkets = [...new Set(mentioningEvents.flatMap(e => e.relatedMarket
   breadcrumbs={[{ label: 'Entities', href: '/entities' }, { label: entity.title }]}
   footerType="entity"
   footerUpdatedBy="Analyst"
-  footerUpdatedAt={entity.lastUpdated || undefined}
+  footerUpdatedAt={entity.pageUpdated || undefined}
   footerSourceCount={mentioningEvents.length}
 >
   <!-- Header Card -->
@@ -53,11 +53,10 @@ const relatedMarkets = [...new Set(mentioningEvents.flatMap(e => e.relatedMarket
       )}
     </div>
     <div class="flex items-center gap-4 text-xs text-[var(--text-faint)]">
-      <FreshnessBadge lastUpdated={entity.lastUpdated} />
-      {diffHours !== null && (
-        <span class="font-mono">Updated {diffHours} hours ago</span>
+      {entity.pageUpdated && (
+        <FreshnessBadge lastUpdated={entity.pageUpdated} label="Page updated" isStub={isStub} />
       )}
-      <span>·</span>
+      {!isStub && <span>·</span>}
       <span class="font-mono">{mentioningEvents.length} events referencing</span>
     </div>
   </div>

--- a/src/pages/entities/index.astro
+++ b/src/pages/entities/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import EntityCard from '../../components/cards/EntityCard.astro';
+import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import { loadAllEntities } from '../../data/loader';
 
 const entities = loadAllEntities();
@@ -8,9 +9,10 @@ const entities = loadAllEntities();
 const types = [...new Set(entities.map((e) => e.type))].filter(Boolean).sort();
 ---
 
-<BaseLayout title="Entities" description="Geopolitical actors — countries, leaders, institutions, and organisations tracked by Signal Intelligence">
+<BaseLayout title="Entities" description="Geopolitical actors — countries, leaders, institutions, and organisations tracked by Signal Intelligence" footerType="page" footerUpdatedBy="Collector" footerSourceCount={entities.length}>
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 mb-2">Entities</h1>
+    <AIAuthoredBadge />
     <p class="text-gray-400">Geopolitical actors — countries, leaders, institutions, media outlets, and armed groups.</p>
   </div>
 

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import StatusBadge from '../../components/badges/StatusBadge.astro';
 import FreshnessBadge from '../../components/badges/FreshnessBadge.astro';
-import FooterMeta from '../../components/shared/FooterMeta.astro';
+
 import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import TimelineSection from '../../components/sections/TimelineSection.astro';
 import EntityCard from '../../components/cards/EntityCard.astro';
@@ -43,6 +43,10 @@ const relatedMarketObjects = event.relatedMarkets
     { label: 'Events', href: '/events' },
     { label: event.title },
   ]}
+  footerType="event"
+  footerUpdatedBy="Analyst"
+  footerUpdatedAt={event.lastUpdated}
+  footerSourceCount={event.relatedEntities.length + event.relatedMarkets.length}
 >
   <div class="mb-8">
     <div class="flex flex-wrap items-start gap-3 mb-4">
@@ -125,10 +129,4 @@ const relatedMarketObjects = event.relatedMarkets
     </section>
   </div>
 
-  <FooterMeta
-    updatedBy="Analyst"
-    updatedAt={event.lastUpdated}
-    sourceCount={event.relatedEntities.length + event.relatedMarkets.length}
-    type="event"
-  />
 </BaseLayout>

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -49,7 +49,7 @@ const relatedMarketObjects = event.relatedMarkets
       <h1 class="text-3xl font-bold text-gray-100 leading-tight">{event.title}</h1>
       <StatusBadge status={event.status} />
       <AIAuthoredBadge />
-      {event.pageUpdated && <FreshnessBadge lastUpdated={event.pageUpdated} label="Page updated" />}
+      {event.pageUpdated && <FreshnessBadge lastUpdated={event.pageUpdated} />}
     </div>
     <div class="flex flex-wrap items-center gap-3 text-sm text-gray-400">
       <span class="inline-flex items-center gap-1.5">

--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -23,10 +23,6 @@ export function getStaticPaths() {
 const { event } = Astro.props;
 const xref = buildCrossReferences();
 
-const diffHours = event.lastUpdated
-  ? Math.floor((Date.now() - new Date(event.lastUpdated).getTime()) / (1000 * 60 * 60))
-  : null;
-
 const relatedEntityObjects = event.relatedEntities
   .map(slug => xref.entityBySlug(slug))
   .filter((e): e is WikiEntity => e !== undefined);
@@ -45,7 +41,7 @@ const relatedMarketObjects = event.relatedMarkets
   ]}
   footerType="event"
   footerUpdatedBy="Analyst"
-  footerUpdatedAt={event.lastUpdated}
+  footerUpdatedAt={event.pageUpdated}
   footerSourceCount={event.relatedEntities.length + event.relatedMarkets.length}
 >
   <div class="mb-8">
@@ -53,10 +49,7 @@ const relatedMarketObjects = event.relatedMarkets
       <h1 class="text-3xl font-bold text-gray-100 leading-tight">{event.title}</h1>
       <StatusBadge status={event.status} />
       <AIAuthoredBadge />
-      <FreshnessBadge lastUpdated={event.lastUpdated} />
-      {diffHours !== null && (
-        <span class="text-sm font-mono text-gray-400">Updated {diffHours} hours ago</span>
-      )}
+      {event.pageUpdated && <FreshnessBadge lastUpdated={event.pageUpdated} label="Page updated" />}
     </div>
     <div class="flex flex-wrap items-center gap-3 text-sm text-gray-400">
       <span class="inline-flex items-center gap-1.5">

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import EventCard from '../../components/cards/EventCard.astro';
+import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import { loadAllEvents } from '../../data/loader';
 
 const events = loadAllEvents();
@@ -10,9 +11,10 @@ const theatres = [...new Set(events.map((e) => e.theatre))].filter(Boolean).sort
 const allThemes = [...new Set(events.flatMap((e) => e.themes))].sort();
 ---
 
-<BaseLayout title="Events" description="Geopolitical events tracked and analysed by Signal Intelligence">
+<BaseLayout title="Events" description="Geopolitical events tracked and analysed by Signal Intelligence" footerType="page" footerUpdatedBy="Collector" footerUpdatedAt={events[0]?.lastUpdated || undefined} footerSourceCount={events.length}>
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 mb-2">Events</h1>
+    <AIAuthoredBadge />
     <p class="text-gray-400">Active geopolitical situations monitored across global theatres.</p>
   </div>
 

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -6,9 +6,9 @@ import { loadAllEvents } from '../../data/loader';
 
 const events = loadAllEvents();
 
-const statuses = [...new Set(events.map((e) => e.status))].sort();
+const statuses = [...new Set(events.map((e) => e.status))].filter((s) => s && s.toLowerCase() !== 'unknown').sort();
 const theatres = [...new Set(events.map((e) => e.theatre))].filter(Boolean).sort();
-const allThemes = [...new Set(events.flatMap((e) => e.themes))].sort();
+const allThemes = [...new Set(events.flatMap((e) => e.themes))].filter((t) => t.trim() !== '').sort();
 ---
 
 <BaseLayout title="Events" description="Geopolitical events tracked and analysed by Signal Intelligence" footerType="page" footerUpdatedBy="Collector" footerUpdatedAt={events[0]?.lastUpdated || undefined} footerSourceCount={events.length}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,8 +39,26 @@ function timeAgo(dateStr: string, timeStr: string): string {
   return `${diffDays}d ago`;
 }
 
+// Relative time from just a date string
+function relativeDate(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 1) return 'today';
+    if (diffDays === 1) return 'yesterday';
+    if (diffDays < 7) return `${diffDays} days ago`;
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  } catch {
+    return dateStr;
+  }
+}
+
 const lastUpdatedText = brief
-  ? `Last updated ${timeAgo(brief.date, brief.time)}`
+  ? `Last updated ${relativeDate(brief.date)}${brief.time ? ` · Brief ${timeAgo(brief.date, brief.time)}` : ''}`
   : 'Data refreshing shortly';
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -44,7 +44,14 @@ const lastUpdatedText = brief
   : 'Data refreshing shortly';
 ---
 
-<BaseLayout title="Signal Intelligence Wiki" description="Real-time geopolitical event tracking, prediction market analysis, and narrative intelligence">
+<BaseLayout
+  title="Signal Intelligence Wiki"
+  description="Real-time geopolitical event tracking, prediction market analysis, and narrative intelligence"
+  footerType="page"
+  footerUpdatedBy="Compiler"
+  footerUpdatedAt={brief?.date || null}
+  footerSourceCount={events.length + entities.length + markets.length}
+>
 
   <!-- HERO SECTION -->
   <section class="py-20 md:py-28 text-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -48,7 +48,7 @@ const lastUpdatedText = brief
   title="Signal Intelligence Wiki"
   description="Real-time geopolitical event tracking, prediction market analysis, and narrative intelligence"
   footerType="page"
-  footerUpdatedBy="Compiler"
+  footerUpdatedBy="System"
   footerUpdatedAt={brief?.date || null}
   footerSourceCount={events.length + entities.length + markets.length}
 >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -81,9 +81,9 @@ const lastUpdatedText = brief
          class="px-6 py-3 rounded-lg bg-teal-500 hover:bg-teal-400 text-white font-medium transition-colors">
         Explore the Wiki
       </a>
-      <a href="https://intel.zyoulabs.ai" target="_blank" rel="noopener"
+      <a href="/events"
          class="px-6 py-3 rounded-lg border border-white/10 hover:border-white/20 text-gray-300 hover:text-white font-medium transition-colors">
-        Today's Brief →
+        Browse Events →
       </a>
     </div>
   </section>

--- a/src/pages/markets/[slug].astro
+++ b/src/pages/markets/[slug].astro
@@ -54,9 +54,12 @@ const relatedEntities = relatedEntitySlugs
   footerSourceCount={relatedEntities.length + market.relatedEvents.length}
 >
   <div class="mb-8 p-6 rounded-card bg-surface border border-[var(--border)]">
-    <h1 class="text-3xl font-medium text-[var(--text-primary)] leading-tight mb-4" style="letter-spacing: -0.704px">
-      {market.title}
-    </h1>
+    <div class="flex items-start justify-between gap-4 mb-4">
+      <h1 class="text-3xl font-medium text-[var(--text-primary)] leading-tight" style="letter-spacing: -0.704px">
+        {market.title}
+      </h1>
+      <AIAuthoredBadge />
+    </div>
     <div class="flex items-center gap-4 text-xs text-[var(--text-faint)] font-mono">
       <FreshnessBadge lastUpdated={market.lastUpdated} />
       {diffHours !== null && (
@@ -99,10 +102,6 @@ const relatedEntities = relatedEntitySlugs
     <div class="p-4 rounded-xl bg-surface border border-[var(--border)]">
       <p class="text-xs text-[var(--text-faint)] uppercase tracking-wider mb-1">Polymarket ID</p>
       <p class="text-sm font-bold font-mono text-[var(--text-primary)] break-all">{market.polymarketId}</p>
-    </div>
-
-    <div class="p-4 rounded-xl bg-surface border border-[var(--border)]">
-      <AIAuthoredBadge />
     </div>
 
     <!-- Data Points -->

--- a/src/pages/markets/[slug].astro
+++ b/src/pages/markets/[slug].astro
@@ -4,7 +4,7 @@ import ProbabilityChart from '../../components/sections/ProbabilityChart.astro';
 import RelatedEvents from '../../components/cross-links/RelatedEvents.astro';
 import EmptyState from '../../components/shared/EmptyState.astro';
 import FreshnessBadge from '../../components/badges/FreshnessBadge.astro';
-import FooterMeta from '../../components/shared/FooterMeta.astro';
+
 import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import EntityCard from '../../components/cards/EntityCard.astro';
 import type { WikiEntity } from '../../data/types';
@@ -48,6 +48,10 @@ const relatedEntities = relatedEntitySlugs
     { label: 'Markets', href: '/markets' },
     { label: market.title },
   ]}
+  footerType="market"
+  footerUpdatedBy="Collector"
+  footerUpdatedAt={market.history.length > 0 ? market.history[market.history.length - 1].timestamp.slice(0, 10) : null}
+  footerSourceCount={relatedEntities.length + market.relatedEvents.length}
 >
   <div class="mb-8 p-6 rounded-card bg-surface border border-[var(--border)]">
     <h1 class="text-3xl font-medium text-[var(--text-primary)] leading-tight mb-4" style="letter-spacing: -0.704px">
@@ -154,10 +158,4 @@ const relatedEntities = relatedEntitySlugs
     )}
   </div>
 
-  <FooterMeta
-    updatedBy="Collector"
-    updatedAt={market.history.length > 0 ? market.history[market.history.length - 1].timestamp.slice(0, 10) : null}
-    sourceCount={relatedEntities.length + market.relatedEvents.length}
-    type="market"
-  />
 </BaseLayout>

--- a/src/pages/markets/index.astro
+++ b/src/pages/markets/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import MarketCard from '../../components/cards/MarketCard.astro';
+import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import { loadAllMarkets } from '../../data/loader';
 
 const markets = loadAllMarkets();
@@ -10,9 +11,10 @@ const sortedByVolume = [...markets].sort((a, b) => {
 });
 ---
 
-<BaseLayout title="Markets" description="Geopolitical prediction markets tracked by Signal Intelligence — probability analysis and trend data">
+<BaseLayout title="Markets" description="Geopolitical prediction markets tracked by Signal Intelligence — probability analysis and trend data" footerType="page" footerUpdatedBy="Collector" footerSourceCount={markets.length}>
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 mb-2">Markets</h1>
+    <AIAuthoredBadge />
     <p class="text-gray-400">Geopolitical prediction markets with probability tracking and trend data.</p>
   </div>
 

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -1,11 +1,13 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import FooterMeta from '../components/shared/FooterMeta.astro';
+import AIAuthoredBadge from '../components/badges/AIAuthoredBadge.astro';
 ---
 
-<BaseLayout title="Methodology" description="How Signal Intelligence collects, processes, and analyses geopolitical intelligence">
+<BaseLayout title="Methodology" description="How Signal Intelligence collects, processes, and analyses geopolitical intelligence" footerType="page" footerUpdatedBy="System">
   <div class="max-w-3xl">
     <h1 class="text-3xl font-bold text-gray-100 mb-6">Methodology</h1>
+    <AIAuthoredBadge />
 
     <div class="space-y-8 text-gray-300 leading-relaxed">
       <section>

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import FooterMeta from '../components/shared/FooterMeta.astro';
+
 import AIAuthoredBadge from '../components/badges/AIAuthoredBadge.astro';
 ---
 
@@ -63,10 +63,4 @@ import AIAuthoredBadge from '../components/badges/AIAuthoredBadge.astro';
     </div>
   </div>
 
-  <FooterMeta
-    updatedBy="Collector"
-    updatedAt={new Date().toISOString().slice(0, 10)}
-    sourceCount={0}
-    type="page"
-  />
 </BaseLayout>

--- a/src/pages/narratives/[slug].astro
+++ b/src/pages/narratives/[slug].astro
@@ -4,7 +4,7 @@ import TimelineSection from '../../components/sections/TimelineSection.astro';
 import RelatedEvents from '../../components/cross-links/RelatedEvents.astro';
 import EmptyState from '../../components/shared/EmptyState.astro';
 import FreshnessBadge from '../../components/badges/FreshnessBadge.astro';
-import FooterMeta from '../../components/shared/FooterMeta.astro';
+
 import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import { loadAllNarratives } from '../../data/loader';
 import { buildCrossReferences } from '../../data/resolvers';
@@ -31,6 +31,10 @@ const diffHours = narrative.lastUpdated
     { label: 'Narratives', href: '/narratives' },
     { label: narrative.title },
   ]}
+  footerType="narrative"
+  footerUpdatedBy="Analyst"
+  footerUpdatedAt={narrative.lastUpdated}
+  footerSourceCount={narrative.relatedEvents.length}
 >
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 leading-tight mb-3">{narrative.title}</h1>
@@ -127,10 +131,4 @@ const diffHours = narrative.lastUpdated
     </section>
   </div>
 
-  <FooterMeta
-    updatedBy="Analyst"
-    updatedAt={narrative.lastUpdated}
-    sourceCount={narrative.relatedEvents.length}
-    type="narrative"
-  />
 </BaseLayout>

--- a/src/pages/narratives/index.astro
+++ b/src/pages/narratives/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import NarrativeCard from '../../components/cards/NarrativeCard.astro';
+import AIAuthoredBadge from '../../components/badges/AIAuthoredBadge.astro';
 import { loadAllNarratives } from '../../data/loader';
 
 const narratives = loadAllNarratives();
@@ -8,9 +9,10 @@ const narratives = loadAllNarratives();
 const allActors = [...new Set(narratives.flatMap((n) => n.pushedBy))].sort();
 ---
 
-<BaseLayout title="Narratives" description="Framing analysis and narrative tracking — how different actors frame geopolitical events">
+<BaseLayout title="Narratives" description="Framing analysis and narrative tracking — how different actors frame geopolitical events" footerType="page" footerUpdatedBy="Collector" footerSourceCount={narratives.length}>
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-100 mb-2">Narratives</h1>
+    <AIAuthoredBadge />
     <p class="text-gray-400">How different actors frame geopolitical events — narrative tracking and counter-narrative analysis.</p>
   </div>
 


### PR DESCRIPTION
## Summary
Fixes #40 — Multiple timestamp display issues across the wiki.

### Changes
1. **Stub entities no longer show "Updated today"** — Empty stub entities now display "Profile pending enrichment" instead of the misleading "Updated today" freshness badge. Added `isStub` prop to FreshnessBadge that suppresses the badge for stubs.

2. **Homepage relative timestamp fixed** — Replaced stale `timeAgo()` calculation with `relativeDate()` that shows proper relative dates ("5 days ago", "yesterday") instead of misleading labels.

3. **Events without dates handled gracefully** — StatusBadge now returns early for empty/"unknown" statuses. Filter dropdowns exclude "unknown" statuses and empty themes.

4. **Malformed date string fixed** — TimelineSection strips leading ")" artifacts from timeline entries (e.g. "2026-04-17) Unknown" → clean text).

5. **Added `pageUpdated` field** — Separated content freshness (`lastUpdated`) from page modification time (`pageUpdated`) across all data types. Entity/event detail pages now use `pageUpdated` for FreshnessBadge.

6. **Cleanup: removed invalid `label` prop** — FreshnessBadge doesn't define a `label` prop; removed `label="Page updated"` from 3 usages.

### Verification
- Build succeeds (`astro build` — 1431 pages, no errors)
- Stub entities show "Profile pending enrichment" ✓
- Homepage shows "Last updated X days ago" ✓
- No "Unknown" status badges on events page ✓
- No malformed dates in timeline entries ✓