### PR TITLE
fix: deduplicate entity pages (#43)

### DIFF
--- a/src/data/loader.ts
+++ b/src/data/loader.ts
@@ -17,7 +17,13 @@ import {
   normalizeEventStatus,
   normalizeTheatre,
   normalizeThemes,
+  isAlternateSlug,
+  resolveCanonicalSlug,
+  ENTITY_ALIASES,
 } from './normalizers';
+
+/** Re-export for use in redirect pages */
+export { ENTITY_ALIASES } from './normalizers';
 import type {
   WikiEvent,
   WikiEntity,
@@ -105,7 +111,8 @@ export function loadAllEvents(): WikiEvent[] {
       themes: normalizeThemes(parseCommaList(sections, 'themes')),
       timeline,
       narrativeDivergence: parseTextBlock(sections, 'narrative divergence'),
-      relatedEntities: cleanBulletList(parseBulletList(sections, 'related entities')),
+      relatedEntities: cleanBulletList(parseBulletList(sections, 'related entities'))
+        .map((e) => resolveCanonicalSlug(e)),
       relatedMarkets: cleanBulletList(parseBulletList(sections, 'related markets')),
       lastUpdated: extractLatestDateFromTimeline(timeline),
     };
@@ -116,7 +123,8 @@ export function loadAllEntities(): WikiEntity[] {
   const dir = path.join(DATA_ROOT, 'wiki', 'entities');
   const files = readDir(dir);
 
-  return files.map((file) => {
+  // Load all entities from source files
+  const allParsed = files.map((file) => {
     const filePath = path.join(dir, file);
     const raw = readFile(filePath);
     const slug = slugFromFilename(file);
@@ -140,7 +148,62 @@ export function loadAllEntities(): WikiEntity[] {
       connections: parseTextBlock(sections, 'connections'),
       lastUpdated,
     };
-  }).sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''));
+  });
+
+  // ── Deduplicate entities (Issue #43) ──
+  // Separate canonical entities from alternate (duplicate) ones
+  const canonicalEntities: WikiEntity[] = [];
+  const alternateEntities: Map<string, WikiEntity> = new Map();
+
+  for (const entity of allParsed) {
+    if (isAlternateSlug(entity.slug)) {
+      alternateEntities.set(entity.slug, entity);
+    } else {
+      canonicalEntities.push(entity);
+    }
+  }
+
+  // Merge content from alternate entities into their canonical counterparts.
+  // For each field, prefer the canonical entity's value if it exists and is
+  // substantive; otherwise, use the alternate entity's value.
+  for (const entity of canonicalEntities) {
+    // Find all alternates that map to this canonical slug
+    const alternates: WikiEntity[] = [];
+    for (const [altSlug, canonicalSlug] of Object.entries(ENTITY_ALIASES)) {
+      if (canonicalSlug.toLowerCase() === entity.slug.toLowerCase()) {
+        const alt = alternateEntities.get(altSlug);
+        if (alt) alternates.push(alt);
+      }
+    }
+
+    if (alternates.length === 0) continue;
+
+    // Merge: for each field, keep the longest/most substantive value
+    const fields: (keyof Pick<WikiEntity, 'affiliations' | 'objectives' | 'claimsAndTrackRecord' | 'divergences' | 'connections'>)[] =
+      ['affiliations', 'objectives', 'claimsAndTrackRecord', 'divergences', 'connections'];
+
+    for (const field of fields) {
+      const currentVal = entity[field];
+      // Find the best value across all alternates (longest non-null value)
+      let bestVal = currentVal;
+      for (const alt of alternates) {
+        const altVal = alt[field];
+        if (altVal && (!bestVal || altVal.length > bestVal.length)) {
+          bestVal = altVal;
+        }
+      }
+      (entity as Record<string, string | null>)[field] = bestVal;
+    }
+
+    // Use the most recent lastUpdated across all duplicates
+    for (const alt of alternates) {
+      if (alt.lastUpdated && (!entity.lastUpdated || alt.lastUpdated > entity.lastUpdated)) {
+        entity.lastUpdated = alt.lastUpdated;
+      }
+    }
+  }
+
+  return canonicalEntities.sort((a, b) => (b.lastUpdated || '').localeCompare(a.lastUpdated || ''));
 }
 
 export function loadAllMarkets(): WikiMarket[] {

--- a/src/data/normalizers.ts
+++ b/src/data/normalizers.ts
@@ -375,3 +375,92 @@ export function normalizeThemes(themes: string[]): string[] {
   const normalized = themes.map(normalizeTheme).filter(Boolean);
   return [...new Set(normalized)].sort();
 }
+
+
+// ── Entity Deduplication (Issue #43) ────────────────────────────────
+
+/**
+ * Canonical slug mapping for duplicate entities.
+ *
+ * The pipeline sometimes creates multiple pages for the same real-world entity
+ * with different slug conventions:
+ *   - al-sharaa vs ahmed-al-sharaa
+ *   - netanyahu vs benjamin-netanyahu vs netanyahu-benjamin
+ *   - munir / asim-munir / munir-asim / pakistan-army-chief-munir
+ *   - etc.
+ *
+ * This map declares the canonical slug for each duplicate group. At load time,
+ * alternate slugs are redirected to the canonical entity. The canonical entity
+ * absorbs the most complete content from all its duplicates.
+ *
+ * Rules for choosing canonical slug:
+ *   1. Prefer the full-name form (e.g. benjamin-netanyahu over netanyahu)
+ *   2. Prefer the slug with the most event/market references (visibility)
+ *   3. Prefer the slug with the richest content
+ */
+export const ENTITY_ALIASES: Record<string, string> = {
+  // al-Sharaa (President of Syria)
+  'al-sharaa': 'ahmed-al-sharaa',
+
+  // Netanyahu (PM of Israel)
+  'netanyahu': 'benjamin-netanyahu',
+  'netanyahu-benjamin': 'benjamin-netanyahu',
+  'netanyahu-government': 'benjamin-netanyahu',
+
+  // Asim Munir (Pakistan Army Chief)
+  'munir': 'asim-munir',
+  'munir-asim': 'asim-munir',
+  'munir-asmad': 'asim-munir',
+  'pakistan-army-chief-munir': 'asim-munir',
+
+  // Pete Hegseth (US Defense Secretary)
+  'hegseth': 'pete-hegseth',
+
+  // Donald Trump (US President)
+  'trump': 'donald-trump',
+  'trump-donald': 'donald-trump',
+
+  // Volodymyr Zelenskyy (President of Ukraine)
+  'zelenskyy': 'volodymyr-zelenskyy',
+  'zelensky-volodymyr': 'volodymyr-zelenskyy',
+
+  // Recep Tayyip Erdoğan (President of Turkey)
+  'erdogan': 'recep-tayyip-erdogan',
+  'erdogan-recep-tayyip': 'recep-tayyip-erdogan',
+
+  // Emmanuel Macron (President of France)
+  'macron': 'emmanuel-macron',
+
+  // Giorgia Meloni (PM of Italy)
+  'meloni-giorgia': 'giorgia-meloni',
+
+  // Peter Magyar (Hungarian opposition leader)
+  'peder-magyar': 'peter-magyar',
+
+  // European Union
+  'eu-commission': 'european-union',
+};
+
+/**
+ * Set of all alternate slugs (keys in ENTITY_ALIASES).
+ * Used to filter out duplicate entities during loading.
+ */
+export const ALTERNATE_ENTITY_SLUGS: Set<string> = new Set(
+  Object.keys(ENTITY_ALIASES).map((k) => k.toLowerCase())
+);
+
+/**
+ * Resolve a slug to its canonical form.
+ * If the slug is an alias, returns the canonical slug; otherwise returns the input.
+ */
+export function resolveCanonicalSlug(slug: string): string {
+  const lower = slug.toLowerCase();
+  return ENTITY_ALIASES[lower] || slug;
+}
+
+/**
+ * Check if a slug is an alternate (non-canonical) alias.
+ */
+export function isAlternateSlug(slug: string): boolean {
+  return ALTERNATE_ENTITY_SLUGS.has(slug.toLowerCase());
+}

--- a/src/data/resolvers.ts
+++ b/src/data/resolvers.ts
@@ -1,5 +1,6 @@
 import type { WikiEvent, WikiEntity, WikiMarket, WikiNarrative, DataCategory } from './types';
 import { loadAllEvents, loadAllEntities, loadAllMarkets, loadAllNarratives } from './loader';
+import { resolveCanonicalSlug } from './normalizers';
 
 export interface SlugIndex {
   get(slug: string): { category: DataCategory; slug: string } | undefined;
@@ -36,9 +37,9 @@ export function buildCrossReferences(): CrossReferences {
 
   return {
     eventsMentioningEntity(entitySlug: string): WikiEvent[] {
-      const slug = entitySlug.toLowerCase();
+      const slug = resolveCanonicalSlug(entitySlug).toLowerCase();
       return events.filter((e) =>
-        e.relatedEntities.some((re) => re.toLowerCase() === slug)
+        e.relatedEntities.some((re) => resolveCanonicalSlug(re).toLowerCase() === slug)
       );
     },
     eventsMentioningMarket(marketSlug: string): WikiEvent[] {

--- a/src/pages/entities/[slug].astro
+++ b/src/pages/entities/[slug].astro
@@ -8,16 +8,40 @@ import TrackRecordSection from '../../components/sections/TrackRecordSection.ast
 import EntityConnections from '../../components/sections/EntityConnections.astro';
 import { loadAllEntities } from '../../data/loader';
 import { buildCrossReferences } from '../../data/resolvers';
+import { ENTITY_ALIASES } from '../../data/normalizers';
 
 export function getStaticPaths() {
   const entities = loadAllEntities();
-  return entities.map((entity) => ({
+  const canonicalSlugs = new Set(entities.map((e) => e.slug.toLowerCase()));
+
+  // Generate canonical entity pages
+  const paths = entities.map((entity) => ({
     params: { slug: entity.slug },
-    props: { entity },
+    props: { entity, isAlias: false, canonicalSlug: null },
   }));
+
+  // Generate redirect pages for alias slugs (Issue #43)
+  for (const [alias, canonical] of Object.entries(ENTITY_ALIASES)) {
+    // Only create redirect if the alias isn't already a canonical slug
+    // (this shouldn't happen, but be defensive)
+    if (!canonicalSlugs.has(alias.toLowerCase())) {
+      paths.push({
+        params: { slug: alias },
+        props: { entity: null, isAlias: true, canonicalSlug: canonical },
+      });
+    }
+  }
+
+  return paths;
 }
 
-const { entity } = Astro.props;
+const { entity, isAlias, canonicalSlug } = Astro.props;
+
+// Redirect alias slugs to their canonical entity page
+if (isAlias) {
+  return Astro.redirect(`/entities/${canonicalSlug}`);
+}
+
 const xref = buildCrossReferences();
 const mentioningEvents = xref.eventsMentioningEntity(entity.slug);
 // Derive related events (slugs) and markets (slugs) for D3 graph from cross-references


### PR DESCRIPTION
Fixes #43

## Problem
Multiple entities have duplicate pages with different slugs (19 duplicate slugs across 11 entity groups).

## Changes
1. ENTITY_ALIASES map in normalizers.ts - declares canonical slug for each duplicate group
2. Content merging in loader.ts - alternate entities filtered out, content merged into canonical
3. Event relatedEntities resolved to canonical slugs
4. Cross-reference resolver resolves aliases when matching events to entities
5. Redirect pages (301) from alternate slugs to canonical entity URLs

## Result
- Before: 368 entity pages (with duplicates)
- After: 349 canonical + 19 redirects
- Build: 1471 pages, no errors
- All filter audit checks pass

Approach: Load-time dedup only, no source markdown files modified.